### PR TITLE
feat: add test to reproduce #605

### DIFF
--- a/src/server/__tests__/ssr.test.ts
+++ b/src/server/__tests__/ssr.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment node
+ */
+import { useState } from 'react'
+import { renderHook, act } from '..'
+
+// This verifies that renderHook can be called in
+// a SSR-like environment.
+describe('renderHook', () => {
+  function useLoading() {
+    if (typeof window !== undefined) {
+      const [loading, setLoading] = useState(false)
+      return { loading, setLoading }
+    }
+  }
+  test('should not throw in SSR environment', () => {
+    expect(() => renderHook(() => useLoading())).not.toThrowError('document is not defined')
+  })
+})

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -2,7 +2,7 @@ import ReactDOMServer from 'react-dom/server'
 import ReactDOM from 'react-dom'
 import { act } from 'react-dom/test-utils'
 
-import { RendererProps, RendererOptions } from '../types/react'
+import { RendererOptions, RendererProps } from '../types/react'
 
 import { createRenderHook } from '../core'
 import { createTestHarness } from '../helpers/createTestHarness'
@@ -12,8 +12,8 @@ function createServerRenderer<TProps, TResult>(
   { wrapper }: RendererOptions<TProps>
 ) {
   let renderProps: TProps | undefined
-  let hydrated = false
-  const container = document.createElement('div')
+  let container: HTMLDivElement | undefined
+  let serverOutput: string = ''
   const testHarness = createTestHarness(rendererProps, wrapper, false)
 
   return {
@@ -21,35 +21,34 @@ function createServerRenderer<TProps, TResult>(
       renderProps = props
       act(() => {
         try {
-          const serverOutput = ReactDOMServer.renderToString(testHarness(props))
-          container.innerHTML = serverOutput
+          serverOutput = ReactDOMServer.renderToString(testHarness(props))
         } catch (e: unknown) {
           rendererProps.setError(e as Error)
         }
       })
     },
     hydrate() {
-      if (hydrated) {
+      if (container) {
         throw new Error('The component can only be hydrated once')
       } else {
+        container.innerHTML = serverOutput
         act(() => {
-          ReactDOM.hydrate(testHarness(renderProps), container)
+          ReactDOM.hydrate(testHarness(renderProps), container!)
         })
-        hydrated = true
       }
     },
     rerender(props?: TProps) {
-      if (!hydrated) {
+      if (!container) {
         throw new Error('You must hydrate the component before you can rerender')
       }
       act(() => {
-        ReactDOM.render(testHarness(props), container)
+        ReactDOM.render(testHarness(props), container!)
       })
     },
     unmount() {
-      if (hydrated) {
+      if (container) {
         act(() => {
-          ReactDOM.unmountComponentAtNode(container)
+          ReactDOM.unmountComponentAtNode(container!)
         })
       }
     },

--- a/src/server/pure.ts
+++ b/src/server/pure.ts
@@ -13,7 +13,7 @@ function createServerRenderer<TProps, TResult>(
 ) {
   let renderProps: TProps | undefined
   let container: HTMLDivElement | undefined
-  let serverOutput: string = ''
+  let serverOutput = ''
   const testHarness = createTestHarness(rendererProps, wrapper, false)
 
   return {
@@ -33,7 +33,7 @@ function createServerRenderer<TProps, TResult>(
       } else {
         container.innerHTML = serverOutput
         act(() => {
-          ReactDOM.hydrate(testHarness(renderProps), container!)
+          ReactDOM.hydrate(testHarness(renderProps), container || null)
         })
       }
     },
@@ -42,13 +42,15 @@ function createServerRenderer<TProps, TResult>(
         throw new Error('You must hydrate the component before you can rerender')
       }
       act(() => {
-        ReactDOM.render(testHarness(props), container!)
+        ReactDOM.render(testHarness(props), container || null)
       })
     },
     unmount() {
       if (container) {
         act(() => {
-          ReactDOM.unmountComponentAtNode(container!)
+          if (typeof container !== 'undefined') {
+            ReactDOM.unmountComponentAtNode(container)
+          }
         })
       }
     },


### PR DESCRIPTION

**What**:

This fixes a bug that assumes that tests don't run in SSR environments.

**Why**:

With frameworks like Next.js and Remix rendering components on the server, it's important that this library can mimic SSR environments as closely as possible.

**How**:

First by adding a test that reproduces the issue and then by moving [this logic](https://github.com/testing-library/react-hooks-testing-library/blob/ef1d731c2a0d7d78e3b33b183d5b5dd927785aae/src/server/pure.ts#L16) "into the hydrate function, so we reference document when they want it to render for real." (suggested by [mpeyper](https://github.com/mpeyper)).

**Checklist**:

- [ ] Documentation updated
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table
